### PR TITLE
Update to resolve relative file path based on curDir

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,10 +11,10 @@ module.exports = function( srcFile, directoryMap ) {
 		var dstDir = typeof directoryMap === 'function' ? directoryMap( curDir ) : directoryMap[ curDir ];
 
 		if( dstDir ) {
-			dstFile = path.resolve( dstDir, path.relative( srcDir, srcFile ) );
+			dstFile = path.resolve( dstDir, path.relative( curDir, srcFile ) );
 			break;
 		}
 	}
-	
+
 	return dstFile ? dstFile : srcFile;
 };

--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ module.exports = function( srcFile, directoryMap ) {
 	var dstFile;
 
 	var curDir = srcFile;
-	var srcDir = path.dirname( srcFile );
 
 	while( curDir !== '' && curDir !== path.sep ) {
 		curDir = path.dirname( curDir );


### PR DESCRIPTION
When getting relative path for '/module/img/sample-img.png' 

```
path.relative( srcDir, srcFile )
```

returns 'sample-img.png'

```
path.relative(curDir, srcFile)
```

returns 'img/sample-img.png'

This change allows for path that is rooted to the same structure with only new parent directory.
I got to this point by using `cartero-node-hook.getAssetUrl` function, which is returning 'fingerprint/sample-img.png' instead of '/fingerprint/img/sample-img.png'.

Please forgive me if this is the wrong place for this update.  Im also not sure about why you chose to compare agaist srcDir?  Could you please let me know.
